### PR TITLE
Fix bug where graphql queries return objects

### DIFF
--- a/src/client/components/LeftContainer/LContComponents/QLogInput.jsx
+++ b/src/client/components/LeftContainer/LContComponents/QLogInput.jsx
@@ -55,12 +55,16 @@ function QLogInput({ qInput, setQInput }) {
   const [results, setResults] = useState('');
 
   // map query results for rendering
-  const updateResults = (queryData) => {
-    const mappedData = Object.entries(queryData).map(([key, values]) =>
-      values.map((value) => value)
-    );
-    return mappedData;
-  };
+const updateResults = (queryData) => {
+  const mappedData = Object.entries(queryData).map(([key, values]) => {
+    if (Array.isArray(values)) {
+      return values.map((value) => value); // Handle arrays
+    } else {
+      return values; // Handle objects directly
+    }
+  });
+  return mappedData;
+};
 
   return (
     <div className="monaco-container">


### PR DESCRIPTION
Issue Type

[ ] Bug
[ x ] Feature
[ ] Tech Debt

Description
Added a conditonal for when the graphql query returns an array or an object. It didin't work with objects before.

Ticket/Card Name
SCRUM-20

Steps to Reproduce Bug / Validate Feature / Confirm Tech Debt Fix

Should see Reactflow tree on homepage (currently uses dummy data)
Expected behavior
n/a

Screenshots & Videos
n/a

Additional context
n/a